### PR TITLE
Added Export/Import of transformer definitions

### DIFF
--- a/config_upgrade.py
+++ b/config_upgrade.py
@@ -3,22 +3,22 @@ import os
 import argparse
 
 
-def upgrade_config(config_file):
+def upgrade_config(current_config, default_config, new_config):
     config = configparser.ConfigParser()
-    config.read(config_file)
-    config.set("DEFAULT", "version", "1.0")
-    with open(config_file, "w") as configfile:
-        config.write(configfile)
+    config.read(default_config)
+    config.read(current_config)
+    config.write(open(new_config, "w"))
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("current_config", help="Config file to upgrade")
-    parser.add_argument("config_file", help="Config file to upgrade")
+    parser.add_argument("-c", "--current_config", help="Current Config file")
+    parser.add_argument("-d", "--default_config", help="Current Config file")
+    parser.add_argument("-n", "--new_config", help="New Config file")
     args = parser.parse_args()
     return args
 
 
 args = main()
 
-upgrade_config(args.config_file)
+upgrade_config(args.current_config, args.default_config, args.new_config)

--- a/controlplane/src/navbar.py
+++ b/controlplane/src/navbar.py
@@ -89,6 +89,14 @@ def create_navbar():
             trigger="hover",
         ),
         dbc.Popover(
+            "Import a transformer JSON file",
+            target="xformer-import-menu-link",
+            id="xformer-import-menu-link-popover",
+            body=True,
+            placement="bottom",
+            trigger="hover",
+        ),
+        dbc.Popover(
             "Edit transformer",
             target="edit-xformer-menu-link",
             id="edit-xformer-menu-link-popover",
@@ -194,6 +202,19 @@ def create_navbar():
                                 href="/xformer-builder",
                                 target="_blank",
                                 id="xformer-builder-menu-link",
+                                disabled=_disable_auth_nav,
+                            )
+                        ),
+                        dbc.NavItem(
+                            dbc.NavLink(
+                                [
+                                    html.I(
+                                        className="fa-solid fa-file-import fa-xl"
+                                    )
+                                ],
+                                href="/xformer-builder?new_xformer=False&import_xformer=True",
+                                target="_blank",
+                                id="xformer-import-menu-link",
                                 disabled=_disable_auth_nav,
                             )
                         ),

--- a/controlplane/src/utils/xformers_build.py
+++ b/controlplane/src/utils/xformers_build.py
@@ -61,7 +61,14 @@ def generate_xformers_from_api(
     if len(_api_response) == 0:
         return []
 
-    xformer_data = XformerData(**_api_response["rows"][0])
+    return xformer_from_json(
+        _api_response["rows"][0], editor_button, editor_code
+    )
+
+
+def xformer_from_json(xformer_json, editor_button, editor_code):
+
+    xformer_data = XformerData(**xformer_json)
     columns = xformer_data.xformer.source_column
     code = xformer_data.xformer.code
     source_type = xformer_data.xformer.source_type

--- a/lib/models.py
+++ b/lib/models.py
@@ -51,7 +51,7 @@ class XformerLists(BaseModel):
 
 class XformerData(BaseModel):
     # Read get xformer response
-    id: str
+    id: Optional[str] = None
     name: str
     description: str
     xformer: XformerLists


### PR DESCRIPTION
You can now export a transformer definition when you save it. The export transformer can then be imported to create a similar transformer.  The code column is base64 encoded. If you want to alter the code, remember to base64 encode it before importing. 